### PR TITLE
Fix build error due to strncpy bounds

### DIFF
--- a/mkbootimg.c
+++ b/mkbootimg.c
@@ -377,7 +377,8 @@ int main(int argc, char **argv)
     hdr.cmdline[BOOT_ARGS_SIZE - 1] = '\0';
     if (cmdlen >= (BOOT_ARGS_SIZE - 1)) {
         cmdline += (BOOT_ARGS_SIZE - 1);
-        strncpy((char *)hdr.extra_cmdline, cmdline, BOOT_EXTRA_ARGS_SIZE);
+        strncpy((char *)hdr.extra_cmdline, cmdline, BOOT_EXTRA_ARGS_SIZE - 1);
+        hdr.extra_cmdline[BOOT_EXTRA_ARGS_SIZE - 1] = '\0';
     }
 
     kernel_data = load_file(kernel_fn, &hdr.kernel_size);


### PR DESCRIPTION
This error is fatal with recent GCC versions:
```
mkbootimg.c:380:9: error: ‘strncpy’ specified bound 1024 equals destination size
```